### PR TITLE
Quick Assist no longer integrated with Windows 10

### DIFF
--- a/IntuneEDU/remote-assist-mobile-devices.md
+++ b/IntuneEDU/remote-assist-mobile-devices.md
@@ -48,7 +48,6 @@ There are four options available to help you remotely help students and teachers
 | Over-the-internet support |![Checkmark](./media/checkmark.png)|![Checkmark](./media/checkmark.png)|![Checkmark](./media/checkmark.png)||
 | Audit reporting |![Checkmark](./media/checkmark.png)||![Checkmark](./media/checkmark.png)|![Checkmark](./media/checkmark.png)|
 | Support for all platforms (Windows, iOS, Android, macOS) |![Checkmark](./media/checkmark.png)||![Checkmark](./media/checkmark.png)||
-| Integrated with Windows 10 – no additional app required ||![Checkmark](./media/checkmark.png)|||
 | Requires device to be co-managed by Configuration Manager and Intune ||||![Checkmark](./media/checkmark.png)|
 | Requires additional licensing\* |![Checkmark](./media/checkmark.png)||![Checkmark](./media/checkmark.png)|![Checkmark](./media/checkmark.png)|
 


### PR DESCRIPTION
I removed the "Integrated with Windows 10" row from the table as that is no longer applicable: https://support.microsoft.com/en-us/windows/install-quick-assist-c17479b7-a49d-4d12-938c-dbfb97c88bca